### PR TITLE
fix: check font.family of current iteration with current family

### DIFF
--- a/app_src/components/modal/editStyle.jsx
+++ b/app_src/components/modal/editStyle.jsx
@@ -257,7 +257,7 @@ const StyleDetails = React.memo(function StyleDetails(props) {
     };
 
     const changeFontStyle = style => {
-        const font = fonts.find(font => (font.style === style));
+        const font = fonts.find(font => ((font.family === family) && (font.style === style)));
         if (!font) return false;
         changeFont(font);
     };


### PR DESCRIPTION
First of all, thank you for developing such amazing tool. I just started to learn about scanlating yesterday and found TyperTools very helpful. I hope this tools could help many for generations to come.

This PR should address #56 where the font family will unexpectedly change if we would like to change font style. This is due to the logic currently used only check for `font.style` which will make the first font that have the selected style will be chosen instead of the correct one. This PR adds a check `font.family === family`.

<details>
<summary>Current master</summary>

![Photoshop_blzi3HEmul](https://github.com/Swirt/typertools-src/assets/57625126/3cf20eed-043e-4b5e-bac0-e4bdd3a00967)

</details>

<details>
<summary>This PR</summary>

![Photoshop_6FQC6cbEQr](https://github.com/Swirt/typertools-src/assets/57625126/73dd4f6a-c38e-4445-80cc-0b76c4cac84a)

</details>

Tested on
- Node 18.19.1
- pnpm 8.15.4
- Photoshop 23.5.2
- Windows 10 21H2

Fix #56